### PR TITLE
Implement deleteTerminal endpoint

### DIFF
--- a/paypro-android-backend/src/main/java/air/found/payproandroidbackend/business_logic/TerminalService.java
+++ b/paypro-android-backend/src/main/java/air/found/payproandroidbackend/business_logic/TerminalService.java
@@ -56,6 +56,20 @@ public class TerminalService {
         return ServiceResult.success(terminals);
     }
 
+
+    public ServiceResult<Boolean> deleteTerminal(Integer terminalId) {
+        Optional<Terminal> terminalOptional = terminalRepository.findById(terminalId);
+
+        if (terminalOptional.isEmpty()) {
+            return ServiceResult.failure(ApiError.ERR_TERMINAL_NOT_FOUND);
+        }
+
+        Terminal terminal = terminalOptional.get();
+        terminalRepository.delete(terminal);
+
+        return ServiceResult.success(null);
+    }
+
     private boolean isValidTerminalKey(String terminalKey) {
         if (terminalKey.length() < 2 || terminalKey.length() > 20) {
             return false;

--- a/paypro-android-backend/src/main/java/air/found/payproandroidbackend/core/ApiError.java
+++ b/paypro-android-backend/src/main/java/air/found/payproandroidbackend/core/ApiError.java
@@ -3,7 +3,8 @@ package air.found.payproandroidbackend.core;
 public enum ApiError {
     ERR_TERMINAL_ALREADY_EXISTS(1, "ERR_TERMINAL_ALREADY_EXISTS", "Terminal with the same key already exists!"),
     ERR_INVALID_TERMINAL_KEY(2, "ERR_INVALID_TERMINAL_KEY", "Invalid terminal key provided!"),
-    ERR_MERCHANT_NOT_FOUND(3, "ERR_MERCHANT_NOT_FOUND", "Merchant with specified ID couldn't be found!")
+    ERR_MERCHANT_NOT_FOUND(3, "ERR_MERCHANT_NOT_FOUND", "Merchant with specified ID couldn't be found!"),
+    ERR_TERMINAL_NOT_FOUND(4, "ERR_TERMINAL_NOT_FOUND", "Terminal with specified ID couldn't be found!")
     ;
 
     private final int errorCode;

--- a/paypro-android-backend/src/main/java/air/found/payproandroidbackend/data_access/persistence/TerminalRepository.java
+++ b/paypro-android-backend/src/main/java/air/found/payproandroidbackend/data_access/persistence/TerminalRepository.java
@@ -9,4 +9,6 @@ public interface TerminalRepository extends JpaRepository<Terminal, Integer> {
     boolean existsByTerminalKey(String terminalKey);
 
     List<Terminal> findByMerchantId(Integer merchantId);
+
+
 }

--- a/paypro-android-backend/src/main/java/air/found/payproandroidbackend/endpoints/controllers/TerminalController.java
+++ b/paypro-android-backend/src/main/java/air/found/payproandroidbackend/endpoints/controllers/TerminalController.java
@@ -49,6 +49,17 @@ public class TerminalController {
             List<Terminal> terminalList = serviceResult.getData();
             return ApiResponseBuilder.buildSuccessResponse(terminalList, "Terminals for merchant successfully retrieved");
         }
+    }
 
+    @DeleteMapping("/{tid}")
+    public ResponseEntity<ResponseBody<Object>> deleteTerminal(@PathVariable("tid") Integer terminalId) {
+        ServiceResult<Boolean> serviceResult = terminalService.deleteTerminal(terminalId);
+
+        if (!serviceResult.isSuccess()) {
+            ApiError apiError = serviceResult.getApiError();
+            return ApiResponseBuilder.buildErrorResponse(HttpStatus.NOT_FOUND, apiError.getErrorMessage(), apiError.getErrorCode(), apiError.getErrorName());
+        } else {
+            return ApiResponseBuilder.buildSuccessResponse(null, "Terminal with id " + terminalId + " successfully deleted!");
+        }
     }
 }


### PR DESCRIPTION
Implemented deleteTerminal api endpoint. The endpoint is `/api/merchant/{mid}/terminal/{tid}`

Currently, only {tid} is being read from the url and deleted based on the id. If it doesn't exist appropriate error is shown.

Later on might consider reading {mid} too. But users who dont own the merchant shouldn't be able to access that endpoint anyway, and terminal ids are unique, so deleting a terminal from different merchant accidentaly won't be possible