### PR TITLE
Implement getAcceptedCardBrandsForMerchant endpoint

### DIFF
--- a/paypro-android-backend/src/main/java/air/found/payproandroidbackend/business_logic/MerchantService.java
+++ b/paypro-android-backend/src/main/java/air/found/payproandroidbackend/business_logic/MerchantService.java
@@ -1,5 +1,7 @@
 package air.found.payproandroidbackend.business_logic;
 
+import air.found.payproandroidbackend.core.ApiError;
+import air.found.payproandroidbackend.core.ServiceResult;
 import air.found.payproandroidbackend.core.enums.CardBrandType;
 import air.found.payproandroidbackend.core.enums.StatusType;
 import air.found.payproandroidbackend.core.models.CardBrand;
@@ -69,6 +71,18 @@ public class MerchantService {
             return false;
         }
     }
+
+    public ServiceResult<Set<CardBrand>> getAcceptedCardBrands(Integer merchantId) {
+        Optional<Merchant> merchantOptional = merchantsRepository.findById(merchantId);
+
+        if (merchantOptional.isEmpty()) {
+            return ServiceResult.failure(ApiError.ERR_MERCHANT_NOT_FOUND);
+        }
+
+        Merchant merchant = merchantOptional.get();
+        return ServiceResult.success(merchant.getAcceptedCardsEnum());
+    }
+
 
     private StatusType getStatusTypeById(Integer id) {
         for(StatusType type : StatusType.values()) {

--- a/paypro-android-backend/src/main/java/air/found/payproandroidbackend/data_access/persistence/MerchantRepository.java
+++ b/paypro-android-backend/src/main/java/air/found/payproandroidbackend/data_access/persistence/MerchantRepository.java
@@ -2,10 +2,6 @@ package air.found.payproandroidbackend.data_access.persistence;
 
 import air.found.payproandroidbackend.core.models.Merchant;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface MerchantRepository extends JpaRepository<Merchant, Integer> {
-
 }

--- a/paypro-android-backend/src/main/java/air/found/payproandroidbackend/endpoints/controllers/MerchantController.java
+++ b/paypro-android-backend/src/main/java/air/found/payproandroidbackend/endpoints/controllers/MerchantController.java
@@ -2,6 +2,9 @@ package air.found.payproandroidbackend.endpoints.controllers;
 
 
 import air.found.payproandroidbackend.business_logic.MerchantService;
+import air.found.payproandroidbackend.core.ApiError;
+import air.found.payproandroidbackend.core.ServiceResult;
+import air.found.payproandroidbackend.core.models.CardBrand;
 import air.found.payproandroidbackend.core.models.Merchant;
 import air.found.payproandroidbackend.core.network.ApiResponseBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import air.found.payproandroidbackend.core.network.ResponseBody;
 
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/merchant")
@@ -53,5 +57,17 @@ public class MerchantController {
         } else {
             return ApiResponseBuilder.buildErrorResponse(HttpStatus.BAD_REQUEST, "Merchant not added", 1, "ERR_MERCHANT_NOT_ADDED");
         }
+    }
+
+    @GetMapping("/{mid}/card-brands")
+    public ResponseEntity<ResponseBody<Set<CardBrand>>> getAcceptedCardBrandsForMerchant(@PathVariable("mid") Integer merchantId) {
+        ServiceResult<Set<CardBrand>> serviceResult = merchantService.getAcceptedCardBrands(merchantId);
+        if (!serviceResult.isSuccess()) {
+            ApiError apiError = serviceResult.getApiError();
+            return ApiResponseBuilder.buildErrorResponse(HttpStatus.NOT_FOUND, apiError.getErrorMessage(), apiError.getErrorCode(), apiError.getErrorName());
+        }
+
+        Set<CardBrand> cardBrands = serviceResult.getData();
+        return ApiResponseBuilder.buildSuccessResponse(cardBrands, "Card brands for merchant with ID " + merchantId + " successfully retrieved!");
     }
 }


### PR DESCRIPTION
Implemented the `/api/merchant/{mid}/card-brands` GET endpoint

Returns a Set of accepted card brands for a merchant

Empty Set if no card brands for merchant are defined

Sends ERR_MERCHANT_NOT_FOUND if invalid merchant id provided

![image](https://github.com/timjuic/paypro-backend-android/assets/70685646/ae066a31-e4f6-4274-bafc-07aa5c1f545f)
![image](https://github.com/timjuic/paypro-backend-android/assets/70685646/904b0144-555f-47ca-86a5-91aabd89ccb4)

